### PR TITLE
Add English translation

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,94 @@
+[![Build Status](https://travis-ci.org/opennorth/ovc-vdm.svg?branch=master)](https://travis-ci.org/opennorth/ovc-vdm)
+
+Other languages: [Français](README.md)
+
+# A tool for visualising contracts for the City of Montreal
+
+Consolidates files contracts and grants from the City of Montreal hosted on [the open data portal](http://donnees.ville.montreal.qc.ca/) to produce:
+
+- A programmable interface (API) according to the [Contracting Open Data Standard](http://standard.open-contracting.org/latest/en/) format and to sort the data according to different parameters
+- Data visualization for listing and exporting contracts and grants. The web interface obtains the data by connecting to the API.
+
+## Dependencies
+
+The API requires the following:
+
+- Python 2.7 or greater
+- Postgresql 9.3 or greater
+
+The code was developed using the [Flask] (http://flask.pocoo.org/) Python microframework. Flask and all other necessary libraries are contained in the file `requirements.txt`.
+
+The project follows standards for hosting on [Heroku](https://heroku.com). That said, it is possible to execute the code on any configuration meeting the above prerequisites; it will be necessary to add a WSGI as [uwsgi] (http://flask.pocoo.org/docs/0.10/deploying/uwsgi/) to link the python code to a web server such as Apache or Nginx.
+
+## Installation
+
+You can clone the code using Git:
+
+``` bash
+git clone https://github.com/opennorth/ovc-vdm.git
+cd ovc-vdm
+```
+
+Or [download a zip](https://github.com/opennorth/ovc-vdm/archive/master.zip).
+
+### Installing Python dependencies
+
+It is recommended that you setup a [virtual environment](http://docs.python-guide.org/en/latest/dev/virtualenvs/) for installing Python dependencies, so as to avoid effecting your wider system.
+
+Once you've done that, install dependencies as follows.
+
+``` bash
+pip install -r requirements.txt
+```
+
+### Environment variables
+
+You need to set the following environment variables prior to running the application:
+
+``` bash
+export APP_SETTINGS="config.DevelopmentConfig"
+export DATABASE_URL="postgresql://USER:PASSWORD@HOST:PORT/DBNAME"
+export EMAIL_CREDENTIALS="user@password"
+```
+
+- `APP_SETTING` sets the configuration mode for running the application. The different modes are configured in the `config.py` file.
+- `DATABASE_URL` tells SQLAlchemy how to connect to the database.
+- `EMAIL_CREDENTIAL` is used to generate alert emails via the platform [SendGrid](https://sendgrid.com).
+
+### Initialize the database
+
+Before running the application, you must setup the initial database schema as follows:
+
+``` bash
+python manage.py db init
+python manage.py db upgrade
+```
+
+### Import data
+
+There are two steps to importing the intial data into the database:
+
+``` bash
+python manage.py update_sources   # Import data sources
+python manage.py update_releases  # Impore contracts and releases - takes a very long time
+```
+
+### Launch the application
+
+``` bash
+python app.py  # Run the development server
+```
+
+To use the application in production mode, it is necessary to start using [WSGI Python](http://www.fullstackpython.com/wsgi-servers.html). To run on the Heroku platform, `procfile` file is already in place.
+
+### Run the tests
+
+``` bash
+./run_test.sh
+```
+
+This uses the [node](http://nose.readthedocs.io/en/latest/) testing library.
+
+## Further documentation
+
+- [API documentation](doc/api.doc.fr.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 [![Build Status](https://travis-ci.org/opennorth/ovc-vdm.svg?branch=master)](https://travis-ci.org/opennorth/ovc-vdm)
 
+Autres langues: [English](README.en.md)
+
 #Outil de visualisation des contracts (OVC) réalisé pour la Ville de Montréal
 
 L'OVC consolide les fichiers de contrats et de subventions de la Ville de Montréal hébergés sur le portail de [données ouvertes](http://donnees.ville.montreal.qc.ca/) pour produire:
@@ -19,13 +21,13 @@ Le projet a été développé en vue d'être déployé sur la plateforme [Heroku
 
 ## Documentation de l'API
 
-Le fonctionnement de l'API est documenté [ici](doc/api.doc.fr.md) 
+Le fonctionnement de l'API est documenté [ici](doc/api.doc.fr.md)
 
 ##Installation
 
 Il est recommandé d'executer les commandes ci-dessous à l'intérieur d'un environnement virtuel à l'aide de [virtualenv/virtualenvwrapper](http://docs.python-guide.org/en/latest/dev/virtualenvs/).
 
-Par exemple 
+Par exemple
 
 ```
 virtualenv /path/to/project
@@ -94,4 +96,3 @@ L'application utilise `nose` réaliser des tests unitaires:
 ```
 ./run_test.sh
 ```
-


### PR DESCRIPTION
An alternative README file, with basically the same content as the original, but translated into English.

I've also linked from the original README to the new one, and vice-versa.
- [Français](https://github.com/nottrobin/ovc-vdm/blob/english/README.md)
- [English](https://github.com/nottrobin/ovc-vdm/blob/english/README.en.md)
